### PR TITLE
Allow CD, not just CDELT

### DIFF
--- a/specutils/io/read_fits.py
+++ b/specutils/io/read_fits.py
@@ -7,7 +7,7 @@ from astropy import units as u
 from specutils.wcs import specwcs
 from specutils import Spectrum1D
 
-def read_fits(filename, dispersion_unit=None, flux_unit=None):
+def read_fits(filename, dispersion_unit=None, flux_unit=None, debug=False):
 
     if dispersion_unit:
         dispersion_unit = u.Unit(dispersion_unit)
@@ -17,7 +17,9 @@ def read_fits(filename, dispersion_unit=None, flux_unit=None):
     for fits_wcs in specwcs.fits_capable_wcs:
         try:
             wcs = fits_wcs.from_fits_header(header, unit=dispersion_unit)
-        except specwcs.Spectrum1DWCSFITSError:
+        except specwcs.Spectrum1DWCSFITSError as E:
+            if debug:
+                print E
             continue
         except specwcs.Spectrum1DWCSUnitError:
             raise specwcs.Spectrum1DWCSUnitError('%s can read WCS information in the file, however no dispersion unit'

--- a/specutils/wcs/specwcs.py
+++ b/specutils/wcs/specwcs.py
@@ -143,12 +143,19 @@ class Spectrum1DLinearWCS(BaseSpectrum1DWCS):
             except (u.UnitsException, TypeError):
                 raise Spectrum1DWCSUnitError("No units were specified and CUNIT did not contain unit information.")
 
+
         try:
             cdelt = header['CDELT%i' % spectroscopic_axis_number]
+        except KeyError:
+            try:
+                cdelt = header['CD%i_%i' % (spectroscopic_axis_number,spectroscopic_axis_number)]
+            except KeyError:
+                raise Spectrum1DWCSFITSError('Necessary keywords (CDELT or CD) missing - can not reconstruct WCS')
+        try:
             crpix = header['CRPIX%i' % spectroscopic_axis_number]
             crval = header['CRVAL%i' % spectroscopic_axis_number]
         except KeyError:
-            raise Spectrum1DWCSFITSError('Necessary keywords (CRDELT, CRPIX, CRVAL) missing - can not reconstruct WCS')
+            raise Spectrum1DWCSFITSError('Necessary keywords (CRPIX, CRVAL) missing - can not reconstruct WCS')
 
         # What happens if both of them are present (fix???)
         #if cdelt is None:


### PR DESCRIPTION
The debug stuff was just so I could see the error messages; it would be best if the FITS reader didn't mask the underlying error message by catching it but I'm not sure how best to do that.

Anyway, the very first file I tried this on used `CD1_1` instead of `CDELT1`, which we should support.
